### PR TITLE
Remove python version from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ path = "package.json"
 pattern = '"version": "(?P<version>.*)"'
 
 [tool.hatch.envs.default]
-python = "3.10"
 dependencies = [
     "ruff",
     "httpx",


### PR DESCRIPTION
This addresses the hatch issue with specifying the Python version - I get exactly the same error (on Python 3.11) as described here: https://github.com/pypa/hatch/issues/906

The workaround is to remove the Python version from the `pyproject.toml`